### PR TITLE
Use Fluent::Config::Element explicitly in test

### DIFF
--- a/test/test_formatter_tsv.rb
+++ b/test/test_formatter_tsv.rb
@@ -8,8 +8,12 @@ class TsvFormatterTest < ::Test::Unit::TestCase
     @time = Fluent::Engine.now
   end
 
+  def e(name, arg='', attrs={}, elements=[])
+    Fluent::Config::Element.new(name, arg, attrs, elements)
+  end
+
   def configure(conf)
-    @formatter.configure({'utc' => true}.merge(conf))
+    @formatter.configure(e('ROOT', '', {'utc' => true}.merge(conf)))
   end
 
   def test_format


### PR DESCRIPTION
In Fluentd 0.12.13 or later, formatter plugin test need to make `Fluent::Config::Element` explicitly and pass to `@ formatter.configure`.
This PR makes easy to refer how to create formatter test against Fluentd new comers.
